### PR TITLE
Added code for maxversion support + label fix

### DIFF
--- a/Sdl.Community.SdlPluginInstaller/Sdl.Community.SdlPluginInstaller/InstallerForm.Designer.cs
+++ b/Sdl.Community.SdlPluginInstaller/Sdl.Community.SdlPluginInstaller/InstallerForm.Designer.cs
@@ -225,6 +225,7 @@ namespace Sdl.Community.SdlPluginInstaller
             // 
             // checkIAgree
             // 
+            this.checkIAgree.AutoSize = true;
             this.checkIAgree.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.checkIAgree.Location = new System.Drawing.Point(12, 275);
             this.checkIAgree.Name = "checkIAgree";

--- a/Sdl.Community.SdlPluginInstaller/Sdl.Community.SdlPluginInstaller/Model/PluginPackageInfo.cs
+++ b/Sdl.Community.SdlPluginInstaller/Sdl.Community.SdlPluginInstaller/Model/PluginPackageInfo.cs
@@ -9,6 +9,7 @@ namespace Sdl.Community.SdlPluginInstaller.Model
         public string Description { get; set; }
         public string PluginName { get; set; }
         public Version MinRequiredProductVersion { get; set; }
+        public Version MaxRequiredProductVersion { get; set; }
         public string Path { get; set; }
 
         private PluginPackageInfo()
@@ -25,6 +26,7 @@ namespace Sdl.Community.SdlPluginInstaller.Model
                 packageInfo.Description = pluginPackage.PackageManifest.Description;
                 packageInfo.Path = pluginPackage.FilePath;
                 packageInfo.MinRequiredProductVersion = pluginPackage.PackageManifest.MinRequiredProductVersion;
+                packageInfo.MaxRequiredProductVersion = pluginPackage.PackageManifest.MaxRequiredProductVersion;
             }
             return packageInfo;
         }

--- a/Sdl.Community.SdlPluginInstaller/Sdl.Community.SdlPluginInstaller/Services/StudioVersionService.cs
+++ b/Sdl.Community.SdlPluginInstaller/Sdl.Community.SdlPluginInstaller/Services/StudioVersionService.cs
@@ -42,7 +42,8 @@ namespace Sdl.Community.SdlPluginInstaller.Services
         public List<StudioVersion> GetNotSupportedStudioVersions()
         {
             return _installedStudioVersions.Where(
-                x => x.ExecutableVersion.CompareTo(_pluginPackage.MinRequiredProductVersion) < 0).ToList();
+                x => x.ExecutableVersion.CompareTo(_pluginPackage.MinRequiredProductVersion) < 0
+                || (_pluginPackage.MaxRequiredProductVersion != null && x.ExecutableVersion.CompareTo(_pluginPackage.MaxRequiredProductVersion) > 0)).ToList();
         }
 
         private void Initialize()


### PR DESCRIPTION
This added code seems to allow support for maxversion, tested by manually hard-coding versions in PluginPackageInfo.CreatePluginPackageInfo().  Now I think all it needs to support maxversion is to find out why the maxversion attribute is not getting passed by the PluginPackage of the Sdl.Core.PluginFramework.PackageSupport library.

Here is the code I used to test the versions:
packageInfo.MinRequiredProductVersion = new Version("11.0"); //etc. packageInfo.MaxRequiredProductVersion = new Version("11.9");  //etc.

Also changed license accept label to auto-size to prevent cutting off with DPI changes.
